### PR TITLE
prevent from failing if adminUsername is not 'admin'

### DIFF
--- a/config/fixtures/user.js
+++ b/config/fixtures/user.js
@@ -12,7 +12,7 @@ exports.create = function (roles, userModel) {
   if (_.isEmpty(sails.config.permissions.adminEmail)) {
     throw new Error('sails.config.permissions.adminEmail is not set');
   }
-  return User.findOne({ username: 'admin' })
+  return User.findOne({ username: sails.config.permissions.adminUsername })
     .then(function (user) {
       if (user) return user;
 


### PR DESCRIPTION
1. set `config.permissions.adminUsername: 'foo'`
2. keep it in db by setting `config.models.migrate == 'alter'`
3. run `sails lift` 2 times

As the user is kept in db, the check is performed against hardcoded `admin` username and should rather be done on `config.permissions.adminUsername` (a validation error is thrown for the moment.)

````
debug: sails-permissions: syncing waterline models
debug: sails-permissions: admin user does not exist; creating...

[...]
 • username
   • A record with that `username` already exists (`xxx`).
 • email
   • A record with that `email` already exists (`xxx@xxx.xxx`).
[...]
```