### PR TITLE
Fixes erroneous assertion in validatePolicyConfig

### DIFF
--- a/api/hooks/sails-permissions.js
+++ b/api/hooks/sails-permissions.js
@@ -104,6 +104,6 @@ function validatePolicyConfig (sails) {
   return _.all([
     _.isArray(policies['*']),
     _.intersection(permissionPolicies, policies['*']).length === permissionPolicies.length,
-    policies.AuthController['*'] = true
+    policies.AuthController['*']
   ]);
 }


### PR DESCRIPTION
Not sure if this is the correct assertion either but at least now it no longer overrides `config.policies.AuthController['*'] = true`.