### PR TITLE
fix for error: column permission.createdBy does not exist

### DIFF
--- a/api/models/Permission.js
+++ b/api/models/Permission.js
@@ -5,6 +5,7 @@
  *   The actions a Role is granted on a particular Model and its attributes
  */
 module.exports = {
+  autoCreatedBy: false,
 
   description: [
     'Defines a particular `action` that a `Role` can perform on a `Model`.',

--- a/api/models/Permission.js
+++ b/api/models/Permission.js
@@ -5,7 +5,6 @@
  *   The actions a Role is granted on a particular Model and its attributes
  */
 module.exports = {
-  autoCreatedBy: false,
 
   description: [
     'Defines a particular `action` that a `Role` can perform on a `Model`.',

--- a/config/fixtures/permission.js
+++ b/config/fixtures/permission.js
@@ -56,7 +56,6 @@ function grantAdminPermissions (roles, models, admin) {
         model: modelEntity.id,
         action: permission.action,
         role: adminRole.id,
-        createdBy: admin.id
       };
       return Permission.findOrCreate(newPermission, newPermission);
     });
@@ -71,27 +70,23 @@ function grantRegisteredPermissions (roles, models, admin) {
     {
       model: _.find(models, { name: 'Permission' }).id,
       action: 'read',
-      role: registeredRole.id,
-      createdBy: admin.id
+      role: registeredRole.id
     },
     {
       model: _.find(models, { name: 'Model' }).id,
       action: 'read',
-      role: registeredRole.id,
-      createdBy: admin.id
+      role: registeredRole.id
     },
     {
       model: _.find(models, { name: 'User' }).id,
       action: 'update',
       role: registeredRole.id,
-      createdBy: admin.id,
       relation: 'owner'
     },
     {
       model: _.find(models, { name: 'User' }).id,
       action: 'read',
       role: registeredRole.id,
-      createdBy: admin.id,
       relation: 'owner'
     }
   ];


### PR DESCRIPTION
fix for part of this: https://github.com/tjwebb/sails-permissions/issues/62
sails-permissions initializes some permissions objects with fixture data,
which includes createdBy fields.  It also sets the permissions model
'autoCreatedBy' to false.  Hence the error.

I removed the createdBy fields from the fixtures, and it loads without error now.