### PR TITLE
Fixes model cache not being found when using sql adapters

### DIFF
--- a/api/policies/ModelPolicy.js
+++ b/api/policies/ModelPolicy.js
@@ -14,7 +14,7 @@ module.exports = function ModelPolicy (req, res, next) {
   req.options.modelDefinition = sails.models[req.options.modelIdentity];
   req.model = modelCache[req.options.modelIdentity];
 
-  if (_.isObject(req.model) && !_.isEmpty(req.model.id)) {
+  if (_.isObject(req.model) && !_.isNull(req.model.id)) {
     return next();
   }
 


### PR DESCRIPTION
ModelPolicy never seems to be able to find the model in the model cache when using sails sql adapters - (since isEmpty returns true with integer ids)