### PR TITLE
Feature/find target objects populate

### DIFF
--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -52,7 +52,7 @@ module.exports = {
    * TODO this will be less expensive when waterline supports a caching layer
    */
   findTargetObjects: function (req) {
-    if (req.options.action === 'add') {
+    if (req.options.action === 'add' || req.options.action === 'remove') {
       return new Promise(function (resolve, reject) {
         populateRecords(req, {
           ok: resolve,

--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -17,6 +17,7 @@ var actionMap = {
 };
 
 var findRecords = require('sails/lib/hooks/blueprints/actions/find');
+var populateRecords = require('sails/lib/hooks/blueprints/actions/populate');
 var wlFilter = require('waterline-criteria');
 
 module.exports = {
@@ -51,12 +52,22 @@ module.exports = {
    * TODO this will be less expensive when waterline supports a caching layer
    */
   findTargetObjects: function (req) {
-    return new Promise(function (resolve, reject) {
-      findRecords(req, {
-        ok: resolve,
-        serverError: reject
+    if (req.options.action === 'add') {
+      return new Promise(function (resolve, reject) {
+        populateRecords(req, {
+          ok: resolve,
+          serverError: reject
+        });
       });
-    });
+    }
+    else {
+      return new Promise(function (resolve, reject) {
+        findRecords(req, {
+          ok: resolve,
+          serverError: reject
+        });
+      });
+    }
   },
 
   /**


### PR DESCRIPTION
If the request is for an `add` or `remove` blueprint then `populate` needs to be used instead of `find`.  This is so the `parentid` and `id` are parsed correctly.

Without this change the `id` from the relation is used by `find` to look up the parent model.