### PR TITLE
add notFound handler to findTargetObjects response object

### DIFF
--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -46,7 +46,10 @@ module.exports = {
     return new Promise(function (resolve, reject) {
       findRecords(req, {
         ok: resolve,
-        serverError: reject
+        serverError: reject,
+        // this isn't perfect, since it returns a 500 error instead of a 404 error
+        // but it is better than crashing the app when a record doesn't exist
+        notFound: reject
       });
     });
   },


### PR DESCRIPTION
this is built on tag 1.3.1

currently trying to 'findOne' on a record that doesn't exist ends up crashing the app, due to res.notFound being called on this fake response object: https://github.com/tjwebb/sails-permissions/blob/master/api/services/PermissionService.js#L55

this is a simple fix for that problem.