### PR TITLE
PermissionService.addUsersToRole: add ids to role.users, not objects

### DIFF
--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -293,7 +293,7 @@ module.exports = {
     }
 
     return Role.findOne({name: rolename}).populate('users').then(function (role) {
-        User.find({username: usernames}).then(function (users) {
+        return User.find({username: usernames}).then(function (users) {
             role.users.add(_.pluck(users, 'id'));
             return role.save();
         });

--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -294,7 +294,7 @@ module.exports = {
 
     return Role.findOne({name: rolename}).populate('users').then(function (role) {
         User.find({username: usernames}).then(function (users) {
-            role.users.add(users);
+            role.users.add(_.pluck(users, 'id'));
             return role.save();
         });
     });


### PR DESCRIPTION
Because if objects are added,
waterline/model/lib/associationMethods/add.js/createAssociations method
tries to create new users. On some adapters it works, because of
duplication checks, but on sails-memory it does not.