### PR TITLE
Use `model.name` instead of `model.globalId`

### DIFF
--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -177,7 +177,7 @@ module.exports = {
    */
   getErrorMessage: function(options) {
     return [
-      'User', options.user.email, 'is not permitted to', options.method, options.model.globalId
+      'User', options.user.email, 'is not permitted to', options.method, options.model.name
     ].join(' ');
   },
 


### PR DESCRIPTION
`globalId` is mapped to `name` here: https://github.com/tjwebb/sails-permissions/blob/6e28e8c4a87799a94e55e8290ac86b99bdf4ed09/config/fixtures/model.js#L10
But was still being referenced in the error that is logged when a user doesn't have the required permission.

This PR changes the log statement to correctly log the model name as was originally intended.