### PR TITLE
move sails-auth to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "mocha": "^2.x.x",
     "request": "^2.58.0",
     "sails": "balderdashy/sails",
-    "sails-auth": "^2.0",
     "sails-memory": "^0.10.5",
     "supertest": "^0.15.0",
     "waterline-postgresql": "^0.12.0"
@@ -54,6 +53,7 @@
     "lodash": "^3.10.0",
     "marlinspike": "^0.12",
     "pluralize": "^1.0.1",
+    "sails-auth": "^2.0",
     "sails-generate-entities": "latest",
     "waterline-criteria": "^0.11.1"
   },


### PR DESCRIPTION
This enables user to omit sails-auth from her application dependencies,
in a situation where her application does not use any sails-auth
features and does not use sails-permissions as a hook.