### PR TITLE
Update permission.js

### DIFF
--- a/config/fixtures/permission.js
+++ b/config/fixtures/permission.js
@@ -40,7 +40,7 @@ var modelRestrictions = {
 exports.create = function (roles, models, admin) {
   return Promise.all([
     grantAdminPermissions(roles, models, admin),
-    grantRegisteredPermissions(roles, models, admin)
+    //grantRegisteredPermissions(roles, models, admin)
   ])
   .then(function (permissions) {
     //sails.log.verbose('created', permissions.length, 'permissions');


### PR DESCRIPTION
Setting default read for everything and making it hard to change is bad, especially after loading large user sets.