### PR TITLE
refs issue #227 fixed owner relation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sails-permissions
 
+[![Looking for maintainers][hacktober-image]][hacktober-url]
+
 [![Gitter][gitter-image]][gitter-url]
 [![NPM version][npm-image]][npm-url]
 [![Build status][travis-image]][travis-url]
@@ -92,3 +94,6 @@ MIT
 [daviddm-url]: https://david-dm.org/langateam/sails-permissions
 [gitter-image]: http://img.shields.io/badge/+%20GITTER-JOIN%20CHAT%20%E2%86%92-1DCE73.svg?style=flat-square
 [gitter-url]: https://gitter.im/langateam/sails-permissions
+
+[hacktober-image]: http://i.imgur.com/FM9yVCI.png
+[hacktober-url]: https://twitter.com/langateam/status/782995392212369408

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # sails-permissions
 
-[![Looking for maintainers][hacktober-image]][hacktober-url]
-
 [![Gitter][gitter-image]][gitter-url]
 [![NPM version][npm-image]][npm-url]
 [![Build status][travis-image]][travis-url]

--- a/api/policies/RolePolicy.js
+++ b/api/policies/RolePolicy.js
@@ -33,8 +33,8 @@ module.exports = function(req, res, next) {
     // Some parsing must happen on the query down the line,
     // as req.query has no impact on the results from PermissionService.findTargetObjects.
     // I had to look at the actionUtil parseCriteria method to see where to augment the criteria
-    req.params.all().where = req.params.all().where || {};
-    req.params.all().where.owner = req.user.id;
+    req.params.where = req.params.all().where || {};
+    req.params.where.owner = req.user.id;
     req.query.owner = req.user.id;
     _.isObject(req.body) && (req.body.owner = req.user.id);
   }


### PR DESCRIPTION
addresses
`error: TypeError: Cannot set property 'owner' of undefined
    at module.exports (/node_modules/sails-permissions/dist/api/policies/RolePolicy.js:43:34)`

req.params.all() returns all parameters merged into a single object. Cannot augment criteria through direct assignment. actionUtil.parseCriteria will find this 'where' parameter instead.
